### PR TITLE
- Open3 will hang if a large amount of data is piped from stdout/stde…

### DIFF
--- a/lib/ffmpeg/version.rb
+++ b/lib/ffmpeg/version.rb
@@ -1,3 +1,3 @@
 module FFMPEG
-  VERSION = '3.0.3'
+  VERSION = '3.0.4'
 end


### PR DESCRIPTION
read error, resulting in a movie object being unable to be initialized.

- This bug is caused by ffmpeg' buffer not being flushed from at the end of the block

- refactored the Open3 block to use while loops on stderr/stdout and append to the std_error and std_output strings, in order to constantly release data from the buffer
- secondary option is to use: `stdout, stderr, status = Open3.capture3(cmd)`

- assigned and exposed with attr_reader the fixed_encoding of std_output and std_error to @error and @output